### PR TITLE
feat: sketch out the homepage copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.jekyll-cache
+/_site

--- a/README.md
+++ b/README.md
@@ -118,11 +118,8 @@ here to help! (Insert here obligatory Doctor Who quote.)
 
 ## Testing Changes Locally
 
-On a Debian/Ubuntu box, install `docker-compose` using:
-
-```bash
-sudo apt install docker-compose
-```
+Install Docker Compose using [the official instructions published on
+the Docker website](https://docs.docker.com/compose/install/).
 
 Then, run the following command to start a local server:
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ from the full post content shown when the post is opened.
 If you run into trouble, [@bassosimone](https://github.com/bassosimone) is
 here to help! (Insert here obligatory Doctor Who quote.)
 
+## Testing Changes Locally
+
+On a Debian/Ubuntu box, install `docker-compose` using:
+
+```bash
+sudo apt install docker-compose
+```
+
+Then, run the following command to start a local server:
+
+```bash
+docker-compose up
+```
+
+and follow the instructions printed on the screen, including the URL of the
+locally-running website, which should be `http://127.0.0.1:4000/`.
+
 ## Architecture
 
 This repository contains a pretty standard [Jekyll](https://jekyllrb.com/)

--- a/_includes/home/description.md
+++ b/_includes/home/description.md
@@ -1,3 +1,15 @@
-The Modeling and Simulation of Techno-Social Systems (MoST) is a
-research unit of the [Digital Society Center](https://digis.fbk.eu/)
-at [Fondazione Bruno Kessler](https://www.fbk.eu/), Trento, Italy.
+The Modeling and Simulation of Techno-Social Systems (MoST) unit at [Fondazione
+Bruno Kessler](https://www.fbk.eu/) develops AI- and data-driven methods to
+model and simulate complex socio-technical systems in support of public
+decision-making and civic participation.
+
+Our research explores human behavior in physical space, with a focus
+on complex systems such as urban mobility, rural infrastructure,
+and environmental resilience. We study how these systems respond to
+stress—such as overcrowding, overtourism, natural disasters, population
+shifts—drawing on multidisciplinary approaches that integrate data
+science, computer engineering, urban planning, and design. Collaborating
+with public institutions and civil society, we co-design methods and tools
+to support understanding, scenario exploration, planning, and decision-making.
+
+The group is part of the [Digital Society Center](https://digis.fbk.eu/).

--- a/_includes/home/impact.md
+++ b/_includes/home/impact.md
@@ -1,0 +1,5 @@
+Our work informs policy decisions, empowers communities, and advances
+scholarly understanding of civic technologies. By embedding
+ethics, transparency, and participation into the development
+of digital tools, we aim to shift the paradigm from surveillance
+and control to empowerment and dialogue.

--- a/_includes/home/impact.md
+++ b/_includes/home/impact.md
@@ -1,5 +1,1 @@
-Our work informs policy decisions, empowers communities, and advances
-scholarly understanding of civic technologies. By embedding
-ethics, transparency, and participation into the development
-of digital tools, we aim to shift the paradigm from surveillance
-and control to empowerment and dialogue.
+

--- a/_includes/home/joinus.md
+++ b/_includes/home/joinus.md
@@ -1,4 +1,1 @@
-Curious about how digital technologies can serve the public
-good? Whether you're a researcher, student, activist, or
-technologist, we welcome interest in collaborations, fellowships,
-and internships. Reach out—we're building this together.
+

--- a/_includes/home/joinus.md
+++ b/_includes/home/joinus.md
@@ -1,0 +1,4 @@
+Curious about how digital technologies can serve the public
+good? Whether you're a researcher, student, activist, or
+technologist, we welcome interest in collaborations, fellowships,
+and internships. Reach out—we're building this together.

--- a/_includes/home/mission.md
+++ b/_includes/home/mission.md
@@ -1,0 +1,9 @@
+We study, model, and simulate complex socio-technical systems to
+support collaborative design, participatory planning, and
+accountable public decision-making. Our work blends computational
+methods, co-design, and domain expertise—for example, in urban
+planning and transportation. We develop production-ready
+digital tools to help institutions, large organizations, and
+communities understand constraints and conflict,
+explore what-if scenarios, and make data-informed decisions in
+high-stakes, real-world contexts.

--- a/_includes/home/researchfocus.md
+++ b/_includes/home/researchfocus.md
@@ -1,0 +1,7 @@
+Our research investigates:
+
+- Civic digital twins as tools for participatory governance
+- Data infrastructures for cities and regions
+- Simulation and modeling of socio-technical systems
+- AI and visualization for collective sensemaking
+- Ethics and impact of digital urban technologies

--- a/_includes/home/researchfocus.md
+++ b/_includes/home/researchfocus.md
@@ -1,7 +1,1 @@
-Our research investigates:
 
-- Civic digital twins as tools for participatory governance
-- Data infrastructures for cities and regions
-- Simulation and modeling of socio-technical systems
-- AI and visualization for collective sensemaking
-- Ethics and impact of digital urban technologies

--- a/_includes/home/strategy.md
+++ b/_includes/home/strategy.md
@@ -1,4 +1,1 @@
-- Interdisciplinarity: we collaborate across domains—from computer science to urban studies
-- Co-design: we involve stakeholders from day one
-- Open Science: we develop reproducible, transparent research
-- Reflexivity: we remain aware of our positionality in shaping civic futures
+

--- a/_includes/home/strategy.md
+++ b/_includes/home/strategy.md
@@ -1,0 +1,4 @@
+- Interdisciplinarity: we collaborate across domains—from computer science to urban studies
+- Co-design: we involve stakeholders from day one
+- Open Science: we develop reproducible, transparent research
+- Reflexivity: we remain aware of our positionality in shaping civic futures

--- a/_includes/home/vision.md
+++ b/_includes/home/vision.md
@@ -1,0 +1,12 @@
+As societies face rapid transformations and increasing interdependence
+between technical and social systems, we envision a future in which
+digital technologies serve as transparent, participatory tools
+that empower citizens and strengthen collective agency. We aim to
+contribute to how society makes sense of complex challenges—such
+as implementing inclusive urban policies, addressing
+congestion in shared spaces and infrastructure, or
+responding to emergencies—through collaborative
+and democratic means. To this end, we champion
+a civic vision in which data-driven systems are
+open, interpretable, and co-designed with the
+relevant institutions, organizations, and communities.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,10 +2,10 @@
 layout: base
 ---
 
+{% include shared/homesection.html source="home/description.md" class="description" %}
 {% include shared/homesection.html source="home/vision.md" class="vision" %}
 {% include shared/homesection.html source="home/mission.md" class="mission" %}
 {% include shared/homesection.html source="home/researchfocus.md" class="researchfocus" %}
-{% include shared/homesection.html source="home/description.md" class="description" %}
 {% include shared/homesection.html source="home/impact.md" class="impact" %}
 {% include shared/homesection.html source="home/strategy.md" class="strategy" %}
 {% include shared/homesection.html source="home/organization.md" class="organization" %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  jekyll:
+    image: jekyll/jekyll:4.2.0
+    command: jekyll serve --watch --force_polling --livereload
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/srv/jekyll
+      - ./vendor/bundle:/usr/local/bundle
+    environment:
+      - JEKYLL_ENV=development


### PR DESCRIPTION
This diff starts sketching out the homepage copy. I used already-available material to patch this up. The intention is to have a sense of what information is in the home page, so that I can then move forward with styling the website. We will revisit this content later on, ahead of publishing the website.

Roughly speaking, this commit covers the first half of the content that should be part of the homepage. Several sections have not been added yet, and we only have empty placeholders representing them.

While there, take stock of the fact that running the website locally is very helpful when making complex changes, and add instructions and configuration for doing this by running `docker-compose`.
