### PR TITLE
feat: create CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+most.fbk.eu.


### PR DESCRIPTION
This tells GitHub that we expect this website to be server under the `most.github.io.` domain. It should configure the `Host: ` header and Let's Encrypt properly, after a little delay.

On our side, instead, we need to update the DNS to have `most.fbk.eu.` be a `CNAME` for `fbk-most.github.io.`.