### PR TITLE
feat: implement basic cookies banner

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -42,5 +42,19 @@
   -->
   <script src="{{ "/assets/vendor/bootstrap/js/bootstrap.bundle.min.js" | relative_url }}"></script>
   <script src="{{ "/assets/js/main.js" | relative_url }}"></script>
+
+  <!-- Cookie Alert -->
+  <div class="most-cookie-alert alert alert-dark text-center fixed-bottom mb-0 d-none" role="alert">
+    <div class="container">
+      <strong>FBK websites use cookies</strong> -
+      <a href="https://www.fbk.eu/en/privacy-cookies-policy/"
+         target="_blank"
+         class="alert-link">More info about Privacy and cookies policy</a>
+      <button type="button" class="btn btn-primary btn-sm ms-3 most-cookie-accept">
+        I agree
+      </button>
+    </div>
+  </div>
+
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -124,3 +124,12 @@
     border-width: 0;
     height: 31px;
 }
+
+/* Cookie Alert */
+.most-cookie-alert {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1030;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,1 +1,55 @@
-/* TODO(bassosimone): add here JavaScript functionality. */
+// mostMaybeCookieAlert shows the cookie alert if it hasn't been shown before.
+function mostMaybeCookieAlert() {
+  // Get the cookie alert elements
+  const cookieAlert = document.querySelector(".most-cookie-alert");
+  const acceptButton = document.querySelector(".most-cookie-accept");
+
+  // Function to set cookie with proper encoding
+  function setCookie(name, value, days) {
+    const encodedName = encodeURIComponent(name);
+    const encodedValue = encodeURIComponent(value);
+    const date = new Date();
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+
+    const cookie = [
+      `${encodedName}=${encodedValue}`,
+      `expires=${date.toUTCString()}`,
+      "path=/",
+      "SameSite=Lax",
+    ].join("; ");
+
+    document.cookie = cookie;
+  }
+
+  // Function to get cookie with proper decoding
+  function getCookie(name) {
+    const encodedName = encodeURIComponent(name);
+    const cookies = document.cookie.split(";");
+
+    for (const cookie of cookies) {
+      const [cookieName, cookieValue] = cookie.trim().split("=");
+      if (cookieName === encodedName) {
+        return decodeURIComponent(cookieValue);
+      }
+    }
+
+    return null;
+  }
+
+  // Define the cookie name
+  const cookieName = "mostCookiesAccepted";
+
+  // Show the alert if the cookie hasn't been set
+  if (!getCookie(cookieName)) {
+    cookieAlert.classList.remove("d-none");
+  }
+
+  // Handle the accept button click
+  acceptButton.addEventListener("click", function () {
+    setCookie(cookieName, "true", 365);
+    cookieAlert.classList.add("d-none");
+  });
+}
+
+// Ensure the cookie alert is shown when needed
+document.addEventListener("DOMContentLoaded", mostMaybeCookieAlert);


### PR DESCRIPTION
We use a cookie to remember the cookie preferences. (Ironic, uh?)

Anyway, this banner should be enough to remove the last blockers preventing us from using `most.fbk.eu`.

Subsequent commits will deal with the website content as well as other details such as the website style.