### PR TITLE
fix(people): sort, make responsive, unclutter

### DIFF
--- a/_includes/people/grid.html
+++ b/_includes/people/grid.html
@@ -4,22 +4,22 @@
 
 {% if include.people.size > 0 %}
   <h2 class="most-people-title">{{ include.title }}</h2>
-  <div class="most-people-grid">
+  <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
     {% for person in include.people %}
-      <div class="most-person-card">
-        {% if person.image and include.show_images != false %}
-          <img src="{{ person.image | relative_url }}" alt="{{ person.name }}">
-        {% endif %}
-        <h3 class="most-person-name">
-          <a href="{{ person.url | relative_url }}">{{ person.name }}</a>
-        </h3>
-        {% if person.position %}
-          <p>{{ person.position }}</p>
-        {% endif %}
-        {% if person.excerpt %}
-          {{ person.excerpt }}
-          <a href="{{ person.url | relative_url }}">Read more about {{ person.name }} ...</a>
-        {% endif %}
+      <div class="col">
+        <div class="card h-100">
+          <div class="card-body most-person-card">
+            {% if person.image and include.show_images != false %}
+              <img src="{{ person.image | relative_url }}" alt="{{ person.name }}">
+            {% endif %}
+            <h3 class="most-person-name">
+              <a href="{{ person.url | relative_url }}">{{ person.name }}</a>
+            </h3>
+            {% if person.position %}
+              <p>{{ person.position }}</p>
+            {% endif %}
+         </div>
+        </div>
       </div>
     {% endfor %}
   </div>

--- a/_people/arianna-burzacchi.md
+++ b/_people/arianna-burzacchi.md
@@ -6,13 +6,12 @@ status: "current"
 image: "/assets/images/people/arianna-burzacchi.jpg"
 github: "araiari"
 scholar: "pjltXLAAAAAJ"
+order: 2
 ---
 
 Arianna Burzacchi is a PostDoc researcher at the [MoST research unit](/).
 She currently works on the modeling and analysis of mobility data
 within the [Bologna Digital Twin](https://pmg.fbk.eu/gdb/) project.
-
-<!--more-->
 
 Before joining [FBK](https://www.fbk.eu/), Arianna was a PhD student at
 the [MOX Laboratory](https://mox.polimi.it/) of Politecnico di Milano,

--- a/_people/guadalupe-escalante.md
+++ b/_people/guadalupe-escalante.md
@@ -4,14 +4,13 @@ name: "Guadalupe Sol Escalante"
 position: "Visiting Student"
 status: "visitor"
 image: "/assets/images/people/guadalupe-escalante.jpg"
+order: 4
 ---
 
 Guadalupe Escalante is a Geospatial Engineer from the National University
 of Córdoba, Argentina; currently doing an internship at the
 [MoST research unit](/), where she explores the contribution
 of remote sensing to digital twins projects.
-
-<!--more-->
 
 Guadalupe is pursuing a Master's degree in Spatial Information
 Applications at the [Gulich Institute](https://ig.conae.unc.edu.ar/)

--- a/_people/luca-gaeta.md
+++ b/_people/luca-gaeta.md
@@ -8,12 +8,11 @@ website: "https://onlineservices.polimi.it/manifesti/manifesti/controller/ricerc
 github: "lgaeta68"
 linkedin: "https://it.linkedin.com/in/luca-gaeta-672b31337"
 research_gate: "https://www.researchgate.net/profile/Luca-Gaeta"
+order: 0
 ---
 
 Luca Gaeta is a Visiting research fellow at the [MoST research
 unit](/) where he studies urban hybrid spaces and related planning issues.
-
-<!--more-->
 
 Beyond visiting [FBK](https://www.fbk.eu/), Luca is a full professor of urban planning
 at Politecnico di Milano, [Department of Architecture and Urban Studies](

--- a/_people/marco-pistore.md
+++ b/_people/marco-pistore.md
@@ -5,14 +5,13 @@ position: "Head of Unit"
 status: "current"
 image: "/assets/images/people/marco-pistore.png"
 linkedin: "https://www.linkedin.com/in/marco-pistore/"
+order: 0
 ---
 
 Marco Pistore is the lead researcher of the [MoST](/) research unit at
 [Fondazione Bruno Kessler](https://www.fbk.eu/). His current research interests focus on novel modeling and simulation
 techniques for complex socio-technical systems (eg. cities, rural areas, complex organizations), by exploiting,
 developing and integrating data science, artificial intelligence and complex systems approaches.
-
-<!--more-->
 
 Marco received his PhD in Computer Science from the University of Pisa in 1998 with a thesis on a theoretical model to
 describe distributed systems with history-dependent behavior.

--- a/_people/maryam-sajedinia.md
+++ b/_people/maryam-sajedinia.md
@@ -7,11 +7,10 @@ image: "/assets/images/people/maryam-sajedinia.jpeg"
 twitter: "maryamsajedinia"
 github: "maryamsajedi"
 scholar: "qsY6O_UAAAAJ"
+order: 4
 ---
 
 Maryam Sajedinia is a Research Assistant at the [MoST research unit](/). She currently works on development of the
 [DT Model](https://github.com/fbk-most/dt-model) evaluation engine.
-
-<!--more-->
 
 Maryam earned a **Master’s degree in Stochastic and Data Science** from the [University of Torino](https://www.unito.it/).

--- a/_people/piergiorgio-vivenzio.md
+++ b/_people/piergiorgio-vivenzio.md
@@ -5,12 +5,11 @@ position: "Visiting PhD Student"
 status: "visitor"
 image: "/assets/images/people/piergiorgio-vivenzio.jpg"
 linkedin: "https://www.linkedin.com/in/piergiorgio-vivenzio-a44720242"
+order: 3
 ---
 
 Piergiorgio Vivenzio is a PhD student in Urban and Regional Development at the Politecnico di Torino.
 He is currently a visiting researcher at FBK's MoST unit, where he is studying and developing a dynamic simulation model of student housing distribution.
-
-<!--more-->
 
 He holds a degree in Statistical and Economic Methods for Decision Making and has worked as a research fellow at the University of Turin.
 He has also collaborated with the startup MetroPolis SRL.

--- a/_people/sammer-sheereen.md
+++ b/_people/sammer-sheereen.md
@@ -5,12 +5,11 @@ position: "PhD Student"
 status: "current"
 image: "/assets/images/people/sammer-sheereen.jpeg"
 github: "ssheereen"
+order: 3
 ---
 
 Sammer Sheereen is a PhD student at the [MoST research unit](/).
 She currently works on the modeling and simulation of Urban Digital Twins.
-
-<!--more--> <!-- excerpt separator -->
 
 Sammer earned a **Master's degree in Applied Mathematics** from Riphah International University,
 focusing her research on Computational Fluid Dynamics (CFD).

--- a/_people/simone-basso.md
+++ b/_people/simone-basso.md
@@ -7,13 +7,12 @@ image: "/assets/images/people/simone-basso.jpg"
 twitter: "bassosimone"
 github: "bassosimone"
 scholar: "f_TerfgAAAAJ"
+order: 1
 ---
 
 Simone Basso is a Senior Technologist at the [MoST research
 unit](/) where he manages the development of the
 [DT Model](https://github.com/fbk-most/dt-model) evaluation engine.
-
-<!--more-->
 
 Before joining [FBK](https://www.fbk.eu/), Simone was measuring
 internet censorship at the [Open Observatory of Network Interference](

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,19 +58,13 @@
 
 /* People page */
 .most-people-title {
-}
-
-.most-people-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 2rem;
+    text-align: center;
     margin: 2rem 0;
 }
 
 .most-person-card {
+    background: #f9f9f9;
     padding: 1rem;
-    background: #f9f9f9; /* This gave the gray block effect */
-    border-radius: 4px;
     text-align: center;
 }
 

--- a/people.md
+++ b/people.md
@@ -4,11 +4,11 @@ title: People
 permalink: /people/
 ---
 
-{% assign current_people = site.people | where: "status", "current" %}
-{% include people/grid.html people=current_people title="Current Team" %}
+{% assign current_people = site.people | where: "status", "current" | sort: "order" %}
+{% include people/grid.html people=current_people title="Team" %}
 
-{% assign visiting_people = site.people | where: "status", "visitor" %}
+{% assign visiting_people = site.people | where: "status", "visitor" | sort: "order" %}
 {% include people/grid.html people=visiting_people title="Visiting" %}
 
-{% assign alumni = site.people | where: "status", "alumni" %}
+{% assign alumni = site.people | where: "status", "alumni" | sort: "order" %}
 {% include people/grid.html people=alumni title="Alumni" %}


### PR DESCRIPTION
This diff sorts the people in the people's page properly.

Additionally, we ensure the page is responsive.

Additionally, we unclutter the page by moving the whole bio inside the personal page and only keeping the position.