### PR TITLE
fix(CNAME): must not be an FQDN

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-most.fbk.eu.
+most.fbk.eu


### PR DESCRIPTION
Apparently, using an FQDN here is not correct and we should instead just use an ordinary domain name.